### PR TITLE
Enabled fallback to cunn

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -6,9 +6,20 @@
 ----  LICENSE file in the root directory of this source tree. 
 ----
 
-require('cunn')
+local ok,cunn = pcall(require, 'fbcunn')
+if not ok then
+    ok,cunn = pcall(require,'cunn')
+    if ok then
+        print("warning: fbcunn not found. Falling back to cunn") 
+        LookupTable = nn.LookupTable
+    else
+        print("Could not find cunn or fbcunn. Either is required")
+        os.exit()
+    end
+else
+    LookupTable = nn.LookupTableGPU
+end
 require('nngraph')
-require('fbcunn')
 require('base')
 local ptb = require('data')
 
@@ -75,7 +86,7 @@ local function create_network()
   local x                = nn.Identity()()
   local y                = nn.Identity()()
   local prev_s           = nn.Identity()()
-  local i                = {[0] = nn.LookupTableGPU(params.vocab_size,
+  local i                = {[0] = LookupTable(params.vocab_size,
                                                     params.rnn_size)(x)}
   local next_s           = {}
   local split         = {prev_s:split(2 * params.layers)}


### PR DESCRIPTION
In the case that fbcunn is not installed, this code should still be able to run with only swapping out `LookupTableGPU` to `LookupTable`.
